### PR TITLE
Add docker build-env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,6 +180,15 @@ images/%.eps : images/%.gif
 images/%.png : images/%.gif
 	giftopnm images/$*.gif | pnmtopng -size "11811 11811 1" > images/$*.png
 
+.PHONY: dockerimage
+dockerimage:
+	echo "User ${USER} userid $(id -u) groupid $(id -g)"
+	docker build --build-arg USERNAME=${USER} \
+				 --build-arg USERID=$(shell id -u) \
+				 --build-arg GROUPID=$(shell id -g) \
+				 -t iptables-tutorial:latest build-env/
+
+
 .PHONY: clean
 clean:
 	rm -rf iptables-tutorial.html iptables-tutorial.ps.gz \

--- a/build-env/Dockerfile
+++ b/build-env/Dockerfile
@@ -1,0 +1,45 @@
+FROM debian:bookworm-slim
+
+LABEL version="0.1"
+LABEL description="Build environment for iptables-tutorial"
+LABEL maintainer="oan@frozentux.net"
+
+ARG USERNAME
+ARG USERID
+ARG GROUPID
+
+ENV USER=${USERNAME}
+ENV DEBIAN_FRONTEND=noninteractive
+
+USER root
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    netpbm \
+    imagemagick \
+    docbook \
+    docbook-dsssl \
+    docbook-website \
+    docbook-xml \
+    docbook-utils \
+    texlive-font-utils \
+    rsync \
+    make \
+    bash
+
+# Fix for ImageMagick
+RUN sed -i 's/domain=\"coder\" rights=\"none\"/domain=\"coder\" rights=\"read\|write\"/g' \
+    /etc/ImageMagick-6/policy.xml
+
+RUN groupadd -g ${GROUPID} ${USERNAME} \
+    && useradd ${USERNAME} \
+    --create-home \
+    --uid ${USERID} \
+    --gid ${GROUPID} \
+    --shell=/bin/bash
+
+USER ${USERNAME}
+
+WORKDIR /home/${USERNAME}
+
+CMD ["bash"]
+


### PR DESCRIPTION
This commit adds a docker build environment based on debian bookworm.

Running these commands should allow you to build the iptables-tutorial inside that docker environment: 

cd build-env && docker build -t iptables-tutorial:latest . && cd .. 
docker run -v /home/osan/Projects/private/iptables-tutorial:/tutorial -it iptables-tutorial:latest /bin/bash